### PR TITLE
refactor: migrate to Supabase + admin CRUD

### DIFF
--- a/src/app/(admin)/admin/courses/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/courses/[id]/edit/page.tsx
@@ -1,34 +1,132 @@
 'use client'
 
-import { useState } from 'react'
-import { Input, Button, Card, Textarea } from '@/components/ui'
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { createClient } from '@/lib/supabase/client'
+import { AdminGuard } from '@/components/AdminGuard'
+import { slugify } from '@/lib/slug'
+import { Textarea } from '@/components/ui/Textarea'
+
+type Row = {
+  id: string
+  title: string | null
+  course_slug: string | null
+  course_category: string | null
+  description: string | null
+  image_url: string | null
+  gform_url: string | null
+}
 
 export default function EditCoursePage() {
-  const [title, setTitle] = useState('')
-  const [description, setDescription] = useState('')
+  const supabase = createClient()
+  const router = useRouter()
+  const params = useParams<{ id: string }>()
+  const [row, setRow] = useState<Row | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true)
+      const { data, error } = await supabase
+        .from('courses')
+        .select('*')
+        .eq('id', params.id)
+        .single()
+      if (error) setErr(error.message)
+      setRow(data as Row)
+      setLoading(false)
+    }
+    load()
+  }, [params.id, supabase])
+
+  async function onSubmit(e: React.FormEvent) {
     e.preventDefault()
-    console.log({ title, description })
-    // TODO: simpan ke Supabase
+    if (!row) return
+    setSaving(true)
+    const { error } = await supabase
+      .from('courses')
+      .update({
+        title: row.title,
+        course_slug: row.course_slug ? slugify(row.course_slug) : slugify(row.title || ''),
+        course_category: row.course_category,
+        description: row.description,
+        image_url: row.image_url || null,
+        gform_url: row.gform_url,
+      })
+      .eq('id', row.id)
+    setSaving(false)
+    if (error) { setErr(error.message); return }
+    router.push('/admin/courses')
   }
 
+  if (loading) return <AdminGuard><div>Memuat…</div></AdminGuard>
+  if (!row) return <AdminGuard><div>Data tidak ditemukan.</div></AdminGuard>
+
   return (
-    <Card className="max-w-2xl mx-auto mt-10">
-      <h1 className="text-xl font-semibold mb-4">Edit Course</h1>
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <Input
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          placeholder="Course title"
-        />
-        <Textarea
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          placeholder="Course description"
-        />
-        <Button type="submit">Save</Button>
-      </form>
-    </Card>
+    <AdminGuard>
+      <div className="max-w-2xl">
+        <h1 className="text-2xl font-semibold mb-4">Edit Kursus</h1>
+        {err && <div className="text-red-500 mb-3">{err}</div>}
+        <form onSubmit={onSubmit} className="space-y-4">
+          <input
+            className="w-full rounded-xl border border-white/20 bg-transparent p-3"
+            placeholder="Judul"
+            value={row.title ?? ''}
+            onChange={(e) => setRow({ ...row, title: e.target.value })}
+            required
+          />
+          <input
+            className="w-full rounded-xl border border-white/20 bg-transparent p-3"
+            placeholder="Slug (opsional)"
+            value={row.course_slug ?? ''}
+            onChange={(e) => setRow({ ...row, course_slug: e.target.value })}
+          />
+          <input
+            className="w-full rounded-xl border border-white/20 bg-transparent p-3"
+            placeholder="Kategori"
+            value={row.course_category ?? ''}
+            onChange={(e) => setRow({ ...row, course_category: e.target.value })}
+          />
+          <input
+            className="w-full rounded-xl border border-white/20 bg-transparent p-3"
+            placeholder="Image URL"
+            value={row.image_url ?? ''}
+            onChange={(e) => setRow({ ...row, image_url: e.target.value })}
+          />
+          <Textarea
+            className="w-full rounded-xl border border-white/20 bg-transparent p-3 min-h-[90px]"
+            placeholder="Deskripsi"
+            value={row.description ?? ''}
+            onChange={(e) => setRow({ ...row, description: e.target.value })}
+          />
+          <input
+            className="w-full rounded-xl border border-white/20 bg-transparent p-3"
+            placeholder="Link Google Form"
+            value={row.gform_url ?? ''}
+            onChange={(e) => setRow({ ...row, gform_url: e.target.value })}
+            required
+          />
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={saving}
+              className="px-4 py-2 rounded-xl bg-white text-black text-sm font-medium disabled:opacity-50"
+            >
+              {saving ? 'Menyimpan…' : 'Simpan'}
+            </button>
+            <button
+              type="button"
+              onClick={() => history.back()}
+              className="px-4 py-2 rounded-xl border border-white/20 text-sm"
+            >
+              Batal
+            </button>
+          </div>
+        </form>
+      </div>
+    </AdminGuard>
   )
 }
+

--- a/src/app/(admin)/admin/courses/new/page.tsx
+++ b/src/app/(admin)/admin/courses/new/page.tsx
@@ -7,12 +7,15 @@ import { Card } from '@/components/ui/Card'
 import { Input } from '@/components/ui/Input'
 import { Textarea } from '@/components/ui/Textarea'
 import { Button } from '@/components/ui/Button'
+import { slugify } from '@/lib/slug'
 
 export default function NewCourse() {
   const supabase = createClient()
   const router = useRouter()
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
+  const [category, setCategory] = useState('')
+  const [imageUrl, setImageUrl] = useState('')
   const [gform, setGform] = useState('')
   const [loading, setLoading] = useState(false)
 
@@ -20,7 +23,12 @@ export default function NewCourse() {
     e.preventDefault()
     setLoading(true)
     const { error } = await supabase.from('courses').insert({
-      title, description: description || null, gform_url: gform
+      title,
+      course_slug: slugify(title),
+      course_category: category || null,
+      description: description || null,
+      image_url: imageUrl || null,
+      gform_url: gform,
     })
     setLoading(false)
     if (!error) router.replace('/admin/courses')
@@ -34,6 +42,8 @@ export default function NewCourse() {
         <Card>
           <form onSubmit={save} className="space-y-3">
             <Input placeholder="Judul" value={title} onChange={e=>setTitle(e.target.value)} required />
+            <Input placeholder="Kategori" value={category} onChange={e=>setCategory(e.target.value)} />
+            <Input placeholder="Image URL" value={imageUrl} onChange={e=>setImageUrl(e.target.value)} />
             <Textarea placeholder="Deskripsi (opsional)" value={description} onChange={e=>setDescription(e.target.value)} />
             <Input placeholder="Link Google Form" value={gform} onChange={e=>setGform(e.target.value)} required />
             <Button type="submit" disabled={loading}>{loading ? 'Menyimpan…' : 'Simpan'}</Button>

--- a/src/app/(admin)/admin/courses/page.tsx
+++ b/src/app/(admin)/admin/courses/page.tsx
@@ -6,14 +6,24 @@ import { createClient } from '@/lib/supabase/client'
 import { Card } from '@/components/ui/Card'
 import { Button } from '@/components/ui/Button'
 
-type Course = { id: string; title: string; gform_url: string; created_at: string }
+type Course = {
+  id: string
+  title: string
+  course_slug: string | null
+  course_category: string | null
+  gform_url: string | null
+  created_at: string | null
+}
 
 export default function AdminCourses() {
   const supabase = createClient()
   const [items, setItems] = useState<Course[]>([])
 
   const load = async () => {
-    const { data } = await supabase.from('courses').select('id,title,gform_url,created_at').order('created_at', { ascending: false })
+    const { data } = await supabase
+      .from('courses')
+      .select('id,title,course_slug,course_category,gform_url,created_at')
+      .order('created_at', { ascending: false })
     setItems(data || [])
   }
 
@@ -37,21 +47,52 @@ export default function AdminCourses() {
         </div>
 
         <Card>
-          <ul className="divide-y divide-white/10">
-            {items.map(x => (
-              <li key={x.id} className="py-3 flex items-center justify-between">
-                <div>
-                  <p className="font-medium">{x.title}</p>
-                  <p className="text-xs text-white/60 line-clamp-1">{x.gform_url}</p>
-                </div>
-                <div className="flex gap-2">
-                  <Link href={`/admin/courses/${x.id}/edit`} className="text-sm underline">Edit</Link>
-                  <button onClick={() => del(x.id)} className="text-sm text-red-400 underline">Hapus</button>
-                </div>
-              </li>
-            ))}
-            {items.length === 0 && <li className="py-6 text-white/60 text-sm">Belum ada data.</li>}
-          </ul>
+          <div className="overflow-x-auto rounded-2xl border border-white/10">
+            <table className="min-w-full text-sm">
+              <thead className="bg-white/5 border-b border-white/10">
+                <tr>
+                  <th className="text-left p-3">Judul</th>
+                  <th className="text-left p-3">Kategori</th>
+                  <th className="text-left p-3">Slug</th>
+                  <th className="text-left p-3">GForm</th>
+                  <th className="text-left p-3 w-40">Aksi</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((r) => (
+                  <tr key={r.id} className="border-b border-white/10">
+                    <td className="p-3">{r.title}</td>
+                    <td className="p-3">{r.course_category || '-'}</td>
+                    <td className="p-3">{r.course_slug || '-'}</td>
+                    <td className="p-3 truncate max-w-[160px]">{r.gform_url}</td>
+                    <td className="p-3">
+                      <div className="flex gap-2">
+                        <Link
+                          href={`/admin/courses/${r.id}/edit`}
+                          className="px-3 py-1 rounded-lg bg-white/10 hover:bg-white/20"
+                        >
+                          Edit
+                        </Link>
+                        <button
+                          onClick={() => del(r.id)}
+                          className="px-3 py-1 rounded-lg bg-red-500/80 hover:bg-red-500 text-white"
+                        >
+                          Hapus
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+                {items.length === 0 && (
+                  <tr>
+                    <td className="p-4 text-white/70" colSpan={5}>
+                      Belum ada data.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
         </Card>
       </div>
     </AdminGuard>

--- a/src/app/(admin)/admin/news/page.tsx
+++ b/src/app/(admin)/admin/news/page.tsx
@@ -30,7 +30,7 @@ export default function AdminNewsListPage() {
     setLoading(false)
   }
 
-  useEffect(() => { load() }, [])
+  useEffect(() => { load() }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   async function onDelete(id: string) {
     if (!confirm('Hapus berita ini?')) return

--- a/src/app/(public)/blog/[id]/page.tsx
+++ b/src/app/(public)/blog/[id]/page.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image'
 import Navbar from '@/components/Navbar'
 import Footer from '@/components/Footer'
 import { Newsletter } from '@/components/ui/Newsletter'
-import { Article, getArticleBySlug, API_URL } from '@/lib/api'
+import { Article, getArticleBySlug } from '@/lib/api'
 
 export default function ArticlePage(
   props: { params: { id: string }, searchParams?: { [key: string]: string | string[] | undefined } }
@@ -85,7 +85,7 @@ export default function ArticlePage(
         {/* Featured Image */}
         <div className="relative w-full h-64 mb-8">
           <Image
-            src={`${API_URL}/storage/artikel-thumbnails/${article.image.split('/').pop()}`}
+            src={article.image_url || '/fallback.jpg'}
             alt={article.title}
             fill
             className="object-contain"

--- a/src/app/(public)/kursus/digital-marketing/page.tsx
+++ b/src/app/(public)/kursus/digital-marketing/page.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import Head from 'next/head'
 import Image from 'next/image'
-import { Course, API_URL } from '@/lib/api'
+import { Course } from '@/lib/api'
 import { courseWithCategory } from '@/components/courseWithCategory'
 
 interface DigitalMarketingCoursePageProps {
@@ -108,13 +108,10 @@ function DigitalMarketingCoursePage({
                     <div key={index} className="bg-white rounded-lg overflow-hidden shadow-sm">
                       <div className="relative h-48">
                         <Image
-                          src={`${API_URL}/storage/artikel-thumbnails/${article.image.split('/').pop()}`}
+                          src={article.image_url || '/keyboard.svg'}
                           alt={article.title}
-                          layout="fill"
-                          objectFit="cover"
-                          onError={(e) => {
-                            e.currentTarget.src = '/keyboard.svg';
-                          }}
+                          fill
+                          className="object-cover"
                         />
                       </div>
                       <div className="p-6">

--- a/src/app/(public)/kursus/machine-learning/page.tsx
+++ b/src/app/(public)/kursus/machine-learning/page.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import Head from 'next/head'
 import Image from 'next/image'
-import { Course, API_URL } from '@/lib/api'
+import { Course } from '@/lib/api'
 import { courseWithCategory } from '@/components/courseWithCategory'
 
 interface MachineLearningCoursePageProps {
@@ -106,13 +106,10 @@ function MachineLearningCoursePage({
                     <div key={index} className="bg-white rounded-lg overflow-hidden shadow-sm">
                       <div className="relative h-48">
                         <Image
-                          src={`${API_URL}/storage/artikel-thumbnails/${article.image.split('/').pop()}`}
+                          src={article.image_url || '/keyboard.svg'}
                           alt={article.title}
-                          layout="fill"
-                          objectFit="cover"
-                          onError={(e) => {
-                            e.currentTarget.src = '/keyboard.svg';
-                          }}
+                          fill
+                          className="object-cover"
                         />
                       </div>
                       <div className="p-6">

--- a/src/app/(public)/kursus/page.tsx
+++ b/src/app/(public)/kursus/page.tsx
@@ -1,49 +1,49 @@
-'use client'
+"use client"
+
 import { useEffect, useState } from 'react'
 import { createClient } from '@/lib/supabase/client'
 
-
 type Course = {
-id: string
-title: string
-description: string
-gform_url: string
+  id: string
+  title: string
+  description: string | null
+  gform_url: string | null
 }
-
 
 export default function KursusPage() {
-const [courses, setCourses] = useState<Course[]>([])
-const supabase = createClient()
+  const [courses, setCourses] = useState<Course[]>([])
+  const supabase = createClient()
 
+  useEffect(() => {
+    const fetchCourses = async () => {
+      const { data } = await supabase.from('courses').select('*')
+      setCourses(data || [])
+    }
+    fetchCourses()
+  }, [supabase])
 
-useEffect(() => {
-const fetchCourses = async () => {
-const { data } = await supabase.from('courses').select('*')
-setCourses(data || [])
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Daftar Kursus</h1>
+      <div className="grid gap-4">
+        {courses.map((course) => (
+          <div key={course.id} className="border p-4 rounded shadow">
+            <h2 className="text-xl font-semibold">{course.title}</h2>
+            <p className="text-sm text-gray-600">{course.description}</p>
+            {course.gform_url && (
+              <a
+                href={course.gform_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block mt-2 text-blue-500 hover:underline"
+              >
+                Daftar Sekarang
+              </a>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
 }
-fetchCourses()
-}, [])
 
-
-return (
-<div className="p-6">
-<h1 className="text-2xl font-bold mb-4">Daftar Kursus</h1>
-<div className="grid gap-4">
-{courses.map(course => (
-<div key={course.id} className="border p-4 rounded shadow">
-<h2 className="text-xl font-semibold">{course.title}</h2>
-<p className="text-sm text-gray-600">{course.description}</p>
-<a
-href={course.gform_url}
-target="_blank"
-rel="noopener noreferrer"
-className="inline-block mt-2 text-blue-500 hover:underline"
->
-Daftar Sekarang
-</a>
-</div>
-))}
-</div>
-</div>
-)
-}

--- a/src/app/(public)/kursus/ui-ux-design/page.tsx
+++ b/src/app/(public)/kursus/ui-ux-design/page.tsx
@@ -3,8 +3,8 @@
 import Link from 'next/link'
 import Head from 'next/head'
 import Image from 'next/image'
-import { useState } from 'react'
 import { courseWithCategory } from '@/components/courseWithCategory'
+import { Course } from '@/lib/api'
 
 interface UiUxDesignCoursePageProps {
   articles: Course[];
@@ -106,13 +106,10 @@ function UiUxDesignCoursePage({
                     <div key={index} className="bg-white rounded-lg overflow-hidden shadow-sm">
                       <div className="relative h-48">
                         <Image
-                          src={`${API_URL}/storage/artikel-thumbnails/${article.image.split('/').pop()}`}
+                          src={article.image_url || '/keyboard.svg'}
                           alt={article.title}
-                          layout="fill"
-                          objectFit="cover"
-                          onError={(e) => {
-                            e.currentTarget.src = '/keyboard.svg';
-                          }}
+                          fill
+                          className="object-cover"
                         />
                       </div>
                       <div className="p-6">

--- a/src/app/(public)/panduan/digital-marketing/page.tsx
+++ b/src/app/(public)/panduan/digital-marketing/page.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import Head from 'next/head'
 import Image from 'next/image'
-import { Article, API_URL } from '@/lib/api'
+import { Article } from '@/lib/api'
 import { Pagination } from '@/components/ui/Pagination'
 import { withCategory } from '@/components/withCategory'
 
@@ -68,7 +68,7 @@ function DigitalMarketingPage({
               <div key={index} className="bg-white rounded-lg overflow-hidden shadow-sm border border-gray-100">
                 <div className="relative h-48 w-full">
                   <Image
-                    src={`${API_URL}/storage/artikel-thumbnails/${article.image.split('/').pop()}`}
+                    src={article.image_url || '/fallback.jpg'}
                     alt={article.title}
                     fill
                     className="object-cover"

--- a/src/app/(public)/panduan/machine-learning/page.tsx
+++ b/src/app/(public)/panduan/machine-learning/page.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import Head from 'next/head'
 import Image from 'next/image'
-import { Article, API_URL } from '@/lib/api'
+import { Article } from '@/lib/api'
 import { Pagination } from '@/components/ui/Pagination'
 import { withCategory } from '@/components/withCategory'
 
@@ -68,7 +68,7 @@ function MachineLearningPage({
               <div key={index} className="bg-white rounded-lg overflow-hidden shadow-sm border border-gray-100">
                 <div className="relative h-48 w-full">
                   <Image
-                    src={`${API_URL}/storage/artikel-thumbnails/${article.image.split('/').pop()}`}
+                    src={article.image_url || '/fallback.jpg'}
                     alt={article.title}
                     fill
                     className="object-cover"

--- a/src/app/(public)/panduan/ui-ux-design/page.tsx
+++ b/src/app/(public)/panduan/ui-ux-design/page.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import Head from 'next/head'
 import Image from 'next/image'
-import { Article, API_URL } from '@/lib/api'
+import { Article } from '@/lib/api'
 import { Pagination } from '@/components/ui/Pagination'
 import { withCategory } from '@/components/withCategory'
 
@@ -68,7 +68,7 @@ function UIUXDesignPage({
               <div key={index} className="bg-white rounded-lg overflow-hidden shadow-sm border border-gray-100">
                 <div className="relative h-48 w-full">
                   <Image
-                    src={`${API_URL}/storage/artikel-thumbnails/${article.image.split('/').pop()}`}
+                    src={article.image_url || '/fallback.jpg'}
                     alt={article.title}
                     fill
                     className="object-cover"

--- a/src/app/(public)/tips/jenjang-karir/page.tsx
+++ b/src/app/(public)/tips/jenjang-karir/page.tsx
@@ -8,7 +8,7 @@ import Footer from '@/components/Footer'
 import { useState, useEffect } from 'react'
 import { Pagination } from '@/components/ui/Pagination'
 import { Newsletter } from '@/components/ui/Newsletter'
-import { getArticlesByCategory, Article, API_URL } from '@/lib/api'
+import { getArticlesByCategory, Article } from '@/lib/api'
 import { ErrorMessage } from '@/components/ui/ErrorMessage'
 import { LoadingArticles } from '@/components/ui/LoadingArticles'
 
@@ -95,10 +95,10 @@ export default function JenjangKarirPage() {
               <div key={article.id} className="bg-white rounded-lg overflow-hidden shadow-sm border border-gray-100">
                 <div className="relative h-48">
                   <Image
-                    src={`${API_URL}/storage/artikel-thumbnails/${article.image.split('/').pop()}`}
+                    src={article.image_url || '/fallback.jpg'}
                     alt={article.title}
-                    layout="fill"
-                    objectFit="contain"
+                    fill
+                    className="object-contain"
                   />
                 </div>
                 <div className="p-6">

--- a/src/app/(public)/tips/lintas-minat/page.tsx
+++ b/src/app/(public)/tips/lintas-minat/page.tsx
@@ -8,7 +8,7 @@ import Footer from '@/components/Footer'
 import { useState, useEffect } from 'react'
 import { Pagination } from '@/components/ui/Pagination'
 import { Newsletter } from '@/components/ui/Newsletter'
-import { getArticlesByCategory, Article, API_URL } from '@/lib/api'
+import { getArticlesByCategory, Article } from '@/lib/api'
 import { ErrorMessage } from '@/components/ui/ErrorMessage'
 import { LoadingArticles } from '@/components/ui/LoadingArticles'
 
@@ -95,10 +95,10 @@ export default function LintasMinatPage() {
               <div key={article.id} className="bg-white rounded-lg overflow-hidden shadow-sm border border-gray-100">
                 <div className="relative h-48">
                   <Image
-                    src={`${API_URL}/storage/artikel-thumbnails/${article.image.split('/').pop()}`}
+                    src={article.image_url || '/fallback.jpg'}
                     alt={article.title}
-                    layout="fill"
-                    objectFit="contain"
+                    fill
+                    className="object-contain"
                   />
                 </div>
                 <div className="p-6">

--- a/src/app/(public)/tips/melamar-kerja/page.tsx
+++ b/src/app/(public)/tips/melamar-kerja/page.tsx
@@ -8,7 +8,7 @@ import Footer from '@/components/Footer'
 import { useState, useEffect } from 'react'
 import { Pagination } from '@/components/ui/Pagination'
 import { Newsletter } from '@/components/ui/Newsletter'
-import { getArticlesByCategory, Article, API_URL } from '@/lib/api'
+import { getArticlesByCategory, Article } from '@/lib/api'
 import { ErrorMessage } from '@/components/ui/ErrorMessage'
 import { LoadingArticles } from '@/components/ui/LoadingArticles'
 
@@ -95,10 +95,10 @@ export default function MelamarKerjaPage() {
               <div key={article.id} className="bg-white rounded-lg overflow-hidden shadow-sm border border-gray-100">
                 <div className="relative h-48">
                   <Image
-                    src={`${API_URL}/storage/artikel-thumbnails/${article.image.split('/').pop()}`}
+                    src={article.image_url || '/fallback.jpg'}
                     alt={article.title}
-                    layout="fill"
-                    objectFit="contain"
+                    fill
+                    className="object-contain"
                   />
                 </div>
                 <div className="p-6">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,35 +1,45 @@
 'use client'
 import { useState } from 'react'
 import { createClient } from '@/lib/supabase/client'
+import { useRouter } from 'next/navigation'
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')
-  const [sent, setSent] = useState(false)
+  const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const supabase = createClient()
+  const router = useRouter()
 
   const login = async (e: React.FormEvent) => {
     e.preventDefault()
-    const { error } = await supabase.auth.signInWithOtp({
-      email,
-      options: {
-        emailRedirectTo: `${window.location.origin}/auth/callback`,
-      }
-    })
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
     if (error) setError(error.message)
-    else setSent(true)
+    else router.replace('/admin')
   }
 
   return (
     <div className="max-w-md mx-auto mt-20">
-      <h1 className="text-xl font-bold mb-4">Login</h1>
-      {sent ? <p>Check email kamu ya!</p> : (
-        <form onSubmit={login} className="space-y-3">
-          <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="email" className="p-2 border w-full rounded" required />
-          <button className="bg-black text-white px-4 py-2 rounded">Login</button>
-          {error && <p className="text-red-500 text-sm">{error}</p>}
-        </form>
-      )}
+      <h1 className="text-xl font-bold mb-4">Login Admin</h1>
+      <form onSubmit={login} className="space-y-3">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+          className="p-2 border w-full rounded"
+          required
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="p-2 border w-full rounded"
+          required
+        />
+        <button className="bg-black text-white px-4 py-2 rounded w-full">Login</button>
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+      </form>
     </div>
   )
 }

--- a/src/components/AdminGuard.tsx
+++ b/src/components/AdminGuard.tsx
@@ -8,6 +8,11 @@ export function AdminGuard({ children }: { children: React.ReactNode }) {
   const router = useRouter()
   const [ok, setOk] = useState<boolean | null>(null)
 
+  const logout = async () => {
+    await supabase.auth.signOut()
+    router.replace('/')
+  }
+
   useEffect(() => {
     const run = async () => {
       const { data: { user } } = await supabase.auth.getUser()
@@ -30,5 +35,12 @@ export function AdminGuard({ children }: { children: React.ReactNode }) {
   }, [router, supabase])
 
   if (ok === null) return <div className="p-6">Memeriksa akses…</div>
-  return <>{children}</>
+  return (
+    <div className="p-6">
+      <div className="flex justify-end mb-6">
+        <button onClick={logout} className="text-sm underline">Logout</button>
+      </div>
+      {children}
+    </div>
+  )
 }

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -53,21 +53,21 @@ export default function Home() {
       category: 'Digital Marketing',
       description:
         'Pelajari SEO, strategi media sosial, dan iklan digital untuk pemasaran yang efektif.',
-      image: '/keyboard.svg',
+      image_url: '/keyboard.svg',
     },
     {
       title: 'Menciptakan Produk Digital yang Menarik',
       category: 'UI/UX Design',
       description:
         'Pelajari prinsip desain antarmuka dan pengalaman pengguna untuk produk yang lebih baik.',
-      image: '/browser.svg',
+      image_url: '/browser.svg',
     },
     {
       title: 'Mulai dari Nol! Kuasai Machine Learning',
       category: 'Machine Learning',
       description:
         'Pelajari konsep, algoritma, dan implementasi Machine Learning untuk karier di bidang AI.',
-      image: '/nlp.svg',
+      image_url: '/nlp.svg',
     },
   ]
 
@@ -450,7 +450,7 @@ export default function Home() {
                   `/icons/${
                     categoryImageMap[course.category] ?? 'browser.svg'
                   }`
-                const imageSrc = course.image || fallback
+                const imageSrc = course.image_url || fallback
                 return (
                   <div
                     key={`${course.title}-${idx}`}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,17 +1,36 @@
-// src/lib/api.ts
 'use client'
 
 import { createClient } from '@supabase/supabase-js'
 
-/** Tipe artikel yang dipakai komponen FE */
+// ----------------- Types -----------------
 export type Article = {
   id: string
   title: string
   slug: string
-  category: string
-  description: string
+  category: string | null
+  description: string | null
+  content?: unknown
   image_url: string | null
   date: string
+}
+
+export type Course = {
+  id: string
+  title: string
+  course_slug: string
+  course_category: string | null
+  description: string | null
+  image_url: string | null
+  gform_url: string | null
+  created_at: string
+}
+
+// --------------- Error class ---------------
+export class ApiError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ApiError'
+  }
 }
 
 const supabase = createClient(
@@ -19,34 +38,96 @@ const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
 )
 
-function slugify(s: string) {
-  return s
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)/g, '')
+// --------------- Helpers ---------------
+type ArticleRow = {
+  id: string
+  title: string | null
+  slug: string | null
+  category: string | null
+  description: string | null
+  content: unknown
+  image_url: string | null
+  created_at: string | null
 }
 
-/** Ambil semua artikel dari tabel `news` di Supabase */
+function mapArticle(row: ArticleRow): Article {
+  return {
+    id: row.id,
+    title: row.title ?? 'Tanpa Judul',
+    slug: row.slug ?? '',
+    category: row.category ?? null,
+    description: row.description ?? null,
+    content: row.content ?? null,
+    image_url: row.image_url ?? null,
+    date: row.created_at ?? new Date().toISOString(),
+  }
+}
+
+type CourseRow = {
+  id: string
+  title: string | null
+  course_slug: string | null
+  course_category: string | null
+  description: string | null
+  image_url: string | null
+  gform_url: string | null
+  created_at: string | null
+}
+
+function mapCourse(row: CourseRow): Course {
+  return {
+    id: row.id,
+    title: row.title ?? 'Tanpa Judul',
+    course_slug: row.course_slug ?? '',
+    course_category: row.course_category ?? null,
+    description: row.description ?? null,
+    image_url: row.image_url ?? null,
+    gform_url: row.gform_url ?? null,
+    created_at: row.created_at ?? new Date().toISOString(),
+  }
+}
+
+// --------------- Article APIs ---------------
 export async function getAllArticles(): Promise<Article[]> {
   const { data, error } = await supabase
     .from('news')
     .select('id,title,slug,category,description,content,image_url,created_at')
     .order('created_at', { ascending: false })
 
-  if (error) {
-    console.error('[getAllArticles] Supabase error:', error)
-    // propagasikan pesan error yang jelas ke UI
-    throw new Error(error.message || 'Gagal memuat artikel')
-  }
-
-  return (data ?? []).map((row: any) => ({
-    id: row.id,
-    title: row.title ?? 'Tanpa Judul',
-    slug: row.slug ?? slugify(row.title ?? 'tanpa-judul'),
-    category: row.category ?? 'General',
-    description: row.description ?? row.content ?? '',
-    image_url: row.image_url ?? null,
-    date: row.created_at ?? new Date().toISOString(),
-  }))
+  if (error) throw new ApiError(error.message)
+  return (data ?? []).map(mapArticle)
 }
+
+export async function getArticlesByCategory(category: string): Promise<Article[]> {
+  const { data, error } = await supabase
+    .from('news')
+    .select('id,title,slug,category,description,content,image_url,created_at')
+    .eq('category', category)
+    .order('created_at', { ascending: false })
+
+  if (error) throw new ApiError(error.message)
+  return (data ?? []).map(mapArticle)
+}
+
+export async function getArticleBySlug(slug: string): Promise<Article | null> {
+  const { data, error } = await supabase
+    .from('news')
+    .select('id,title,slug,category,description,content,image_url,created_at')
+    .eq('slug', slug)
+    .single()
+
+  if (error) throw new ApiError(error.message)
+  return data ? mapArticle(data) : null
+}
+
+// --------------- Course APIs ---------------
+export async function getAllCourses(): Promise<Course[]> {
+  const { data, error } = await supabase
+    .from('courses')
+    .select('id,title,course_slug,course_category,description,image_url,gform_url,created_at')
+    .order('created_at', { ascending: false })
+
+  if (error) throw new ApiError(error.message)
+  return (data ?? []).map(mapCourse)
+}
+


### PR DESCRIPTION
## Summary
- standardize API layer for articles and courses using Supabase
- add email/password admin login with logout guard
- implement full CRUD pages for courses and migrate public pages to Supabase image URLs

## Environment
- `NEXT_PUBLIC_SUPABASE_URL`
- `NEXT_PUBLIC_SUPABASE_ANON_KEY`

## SQL RLS
```sql
-- News
alter table news enable row level security;
create policy "Public read" on news for select using (true);
create policy "Admin manage" on news for all using (
  exists (select 1 from profiles p where p.id = auth.uid() and p.is_admin)
);

-- Courses
alter table courses enable row level security;
create policy "Public read" on courses for select using (true);
create policy "Admin manage" on courses for all using (
  exists (select 1 from profiles p where p.id = auth.uid() and p.is_admin)
);

-- Profiles
alter table profiles enable row level security;
create policy "Admins manage profiles" on profiles for all using (is_admin);
create policy "Users read own profile" on profiles for select using (auth.uid() = id);
```


------
https://chatgpt.com/codex/tasks/task_e_68a73126b55883218c5813b89b81b9ac